### PR TITLE
send mechanism as raw string to fix compatibility issues

### DIFF
--- a/command.go
+++ b/command.go
@@ -15,7 +15,7 @@ type Command struct {
 func (cmd *Command) Command() *imap.Command {
 	return &imap.Command{
 		Name:      commandName,
-		Arguments: []interface{}{cmd.Mechanism},
+		Arguments: []interface{}{imap.RawString(cmd.Mechanism)},
 	}
 }
 


### PR DESCRIPTION
Hi @emersion,

while attempting to use your fantastic library in a project of mine, I stumbed accross the fact that I couldn't activate COMPRESS with the IMAP server of mailbox.org even though the server clearly advertises the capability. From that I can tell, they use Dovecot.

When executing `comp.Compress(compress.Deflate)` I'd always get `Error in IMAP command COMPRESS: Invalid arguments (0.001 + 0.000 secs).`.
I realized, that COMPRESS seems to work in Thunderbird though and tried to debug the issue.
Turns out, Thunderbird activates COMPRESS like this:
```
2020-11-03 18:04:09.183815 UTC - [(null) 47058: IMAP]: I/IMAP 0x12d5cc800:imap.mailbox.org:NA:CreateNewLineFromSocket: 1 OK [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE SORT SORT=DISPLAY THREAD=REFERENCES THREAD=REFS THREAD=ORDEREDSUBJECT MULTIAPPEND URL-PARTIAL CATENATE UNSELECT CHILDREN NAMESPACE UIDPLUS LIST-EXTENDED I18NLEVEL=1 CONDSTORE QRESYNC ESEARCH ESORT SEARCHRES WITHIN CONTEXT=SEARCH LIST-STATUS BINARY MOVE SNIPPET=FUZZY PREVIEW=FUZZY STATUS=SIZE SEARCH=X-MIMEPART XDOVECOT ACL UIDPLUS LI
2020-11-03 18:04:09.183824 UTC - [(null) 47058: IMAP]: I/IMAP TERAL+ NOTIFY SPECIAL-USE FILTER=SIEVE COMPRESS=DEFLATE XAPPLEPUSHSERVICE QUOTA ACL RIGHTS=texk] Logged in
2020-11-03 18:04:09.183830 UTC - [(null) 47058: IMAP]: D/IMAP SetConnectionStatus(0x0)
2020-11-03 18:04:09.184028 UTC - [(null) 47058: IMAP]: D/IMAP login succeeded
2020-11-03 18:04:09.184220 UTC - [(null) 47058: IMAP]: I/IMAP 0x12d5cc800:imap.mailbox.org:A:SendData: 2 COMPRESS DEFLATE
2020-11-03 18:04:09.221368 UTC - [(null) 47058: IMAP]: D/IMAP ReadNextLine [rv=0x0 stream=0x12df1a820 nb=46 needmore=0]
2020-11-03 18:04:09.221393 UTC - [(null) 47058: IMAP]: I/IMAP 0x12d5cc800:imap.mailbox.org:A:CreateNewLineFromSocket: 2 OK Begin compression (0.001 + 0.000 secs).
```

While `go-imap-compress` does it like this
```
YTEVSw COMPRESS "DEFLATE"
YTEVSw BAD Error in IMAP command COMPRESS: Invalid arguments (0.001 + 0.000 secs).
```
Notice DEFLATE (no quotes) vs "DEFLATE" (with quotes).

After I did some digging, I realized that changing the arguments of the cmd to RawString would avoid these quotes. I applied this patch and the connection seems to work!

I don't know if this causes compatibility issues with other IMAP servers, I don't see quotes in [RFC4978](https://tools.ietf.org/html/rfc4978) though. I'm also not sure if I nailed the Parse() code, that method wasn't called and I'm not sure of the intended behaviour there.

Thanks for writing such a nice IMAP library @emersion! I had no prior knowledge of IMAP and even though IMAP itself wasn't intuitive to me I was able to get everything I wanted working so far :)

Thanks & regards,
Johannes